### PR TITLE
Fix sessionInformation chunks and update path to GitHub repo

### DIFF
--- a/analysis/_site.yml
+++ b/analysis/_site.yml
@@ -13,7 +13,7 @@ navbar:
       href: license.html
   right:
     - icon: fa-github
-      href: https://github.com/jdblischak/workflowr
+      href: https://github.com/stephenslab/fast-ash
 output:
   html_document:
     toc: true

--- a/analysis/ash_stages.Rmd
+++ b/analysis/ash_stages.Rmd
@@ -77,5 +77,5 @@ Now the full output takes more than half the elapsed time, and about half the us
 
 ## Session information
 
-```{r info, echo = FALSE}
+```{r session-info, echo = FALSE}
 ```

--- a/analysis/ash_z_pi_changes.Rmd
+++ b/analysis/ash_z_pi_changes.Rmd
@@ -75,5 +75,5 @@ n_within_tol(93750)
 
 ## Session information
 
-```{r info, echo = FALSE}
+```{r session-info, echo = FALSE}
 ```

--- a/analysis/general_approach.Rmd
+++ b/analysis/general_approach.Rmd
@@ -80,5 +80,5 @@ My guess is that EM is slowed down by all those very-near-zero components.
 
 ## Session information
 
-```{r info, echo = FALSE}
+```{r session-info, echo = FALSE}
 ```

--- a/analysis/test_fix_point.Rmd
+++ b/analysis/test_fix_point.Rmd
@@ -72,5 +72,5 @@ EM5
 
 ## Session information
 
-```{r info, echo = FALSE}
+```{r session-info, echo = FALSE}
 ```

--- a/analysis/test_mmult.Rmd
+++ b/analysis/test_mmult.Rmd
@@ -40,5 +40,5 @@ m <- microbenchmark( mmult1( v , mat ) , mmult(mat,v), sweep(mat, 2, v, FUN = "*
 
 ## Session information
 
-```{r info, echo = FALSE}
+```{r session-info, echo = FALSE}
 ```

--- a/analysis/test_rcpp.Rmd
+++ b/analysis/test_rcpp.Rmd
@@ -90,5 +90,5 @@ system.time(add_to_wsum(lprobsum,wsum,pi,lik,0,nsamp-1,0,0,tol=1e-5))
 
 ## Session information
 
-```{r info, echo = FALSE}
+```{r session-info, echo = FALSE}
 ```


### PR DESCRIPTION
You'll need to run `render_site` to have the GiHub repo link updated in the navbar for every single page of the website.